### PR TITLE
amount of esdl federates is equal to amount om models +1

### DIFF
--- a/simulation_orchestrator/dataclasses/CalculationServiceInfo.py
+++ b/simulation_orchestrator/dataclasses/CalculationServiceInfo.py
@@ -9,6 +9,7 @@ class CalculationServiceInfo:
     calc_service_name : str
     service_image_url : str
     nr_of_models : int
+    amount_of_calculations : int
     esdl_type : str
     esdl_ids : List[EsdlId]
     additional_environment_variables : List[EnvironmentVariable]

--- a/simulation_orchestrator/model_services_orchestrator/k8s_api.py
+++ b/simulation_orchestrator/model_services_orchestrator/k8s_api.py
@@ -134,7 +134,7 @@ class K8sApi:
         }
         env_vars = self.generic_model_env_var
         env_vars["esdl_ids"] = ';'.join(model.esdl_ids)
-        env_vars["esdl_type"] = model.esdl_type
+        env_vars["esdl_type"] = model.calc_service.esdl_type
         env_vars["broker_ip"] = broker_ip
         env_vars["broker_port"] = str(HELICS_BROKER_PORT)
         env_vars["simulation_id"] = simulation.simulation_id
@@ -143,9 +143,9 @@ class K8sApi:
         env_vars["start_time"] = simulation.simulation_start_datetime.strftime(format="%Y-%m-%d %H:%M:%S")
         env_vars["simulation_duration_in_seconds"] = str(simulation.simulation_duration_in_seconds)
         env_vars["log_level"] = simulation.log_level
-        for env_var_value in model.additional_env_variables:
+        for env_var_value in model.calc_service.additional_environment_variables:
             env_vars[env_var_value.name] = env_var_value.value
-        return self.deploy_new_pod(pod_name, model.service_image_url,[kubernetes.client.V1EnvVar(name, value) for name, value in env_vars.items()], labels)
+        return self.deploy_new_pod(pod_name, model.calc_service.service_image_url,[kubernetes.client.V1EnvVar(name, value) for name, value in env_vars.items()], labels)
 
     def delete_model(self, simulator_id: SimulatorId, simulation_id: SimulationId, model_id: ModelId,
                            delete_by: datetime) -> bool:

--- a/simulation_orchestrator/parse_esdl.py
+++ b/simulation_orchestrator/parse_esdl.py
@@ -6,7 +6,7 @@ from esdl.esdl_handler import EnergySystemHandler
 from base64 import b64decode
 
 from simulation_orchestrator.rest.schemas.CalculationService import CalculationService
-from simulation_orchestrator.dataclasses.dataclasses import CalculationServiceInfo
+from simulation_orchestrator.dataclasses.CalculationServiceInfo import CalculationServiceInfo
 from simulation_orchestrator.simulation_logic.model_inventory import Model
 from simulation_orchestrator.types import EsdlId, ProgressState
 
@@ -38,7 +38,7 @@ def add_esdl_object(service_info_dict: dict[str, CalculationServiceInfo], calcul
         if calc_service.calc_service_name in service_info_dict:
             service_info_dict[calc_service.calc_service_name].esdl_ids.append(esdl_obj.id)
         else:
-            service_info_dict[calc_service.calc_service_name] = CalculationServiceInfo(calc_service.calc_service_name, calc_service.service_image_url, calc_service.nr_of_models, type(esdl_obj).__name__, [esdl_obj.id], calc_service.additional_env_variable)
+            service_info_dict[calc_service.calc_service_name] = CalculationServiceInfo(calc_service.calc_service_name, calc_service.service_image_url, calc_service.nr_of_models, calc_service.amount_of_calculations, type(esdl_obj).__name__, [esdl_obj.id], calc_service.additional_env_variable)
 
 def get_model_list(calculation_services: List[CalculationService], esdl_base64string: str) -> List[Model]:
     try:
@@ -84,10 +84,7 @@ def add_service_models(service_info : CalculationServiceInfo, model_list):
             Model(
                 model_id=model_id,
                 esdl_ids=esdl_ids,
-                calc_service_name=service_info.calc_service_name,
-                service_image_url=service_info.service_image_url,
-                esdl_type=service_info.esdl_type,
-                current_state=ProgressState.REGISTERED,
-                additional_env_variables=service_info.additional_environment_variables
+                calc_service=service_info,
+                current_state=ProgressState.REGISTERED
             )
         )

--- a/simulation_orchestrator/simulation_logic/model_inventory.py
+++ b/simulation_orchestrator/simulation_logic/model_inventory.py
@@ -1,9 +1,10 @@
 import typing
 
+from simulation_orchestrator.dataclasses.CalculationServiceInfo import CalculationServiceInfo
 from simulation_orchestrator.io.log import LOGGER
 
 from simulation_orchestrator.rest.schemas.EnvironmentVariable import EnvironmentVariable
-from simulation_orchestrator.types import EsdlId, SimulationId, ModelId, ProgressState
+from simulation_orchestrator.types import SimulationId, ModelId, ProgressState
 
 from typing import List
 
@@ -15,23 +16,16 @@ class Model:
     service_image_url: str
     esdl_type : str
     current_state: ProgressState
-    additional_environment_variables : List[EnvironmentVariable]
 
     def __init__(self,
                  model_id: ModelId,
                  esdl_ids: typing.List[str],
-                 calc_service_name: str,
-                 service_image_url: str,
-                 esdl_type : str,
-                 current_state: ProgressState,
-                 additional_env_variables : List[EnvironmentVariable]):
+                 calc_service: CalculationServiceInfo,
+                 current_state: ProgressState):
         self.model_id = model_id
         self.esdl_ids = esdl_ids
-        self.calc_service_name = calc_service_name
-        self.service_image_url = service_image_url
-        self.esdl_type = esdl_type
+        self.calc_service = calc_service
         self.current_state = current_state
-        self.additional_env_variables = additional_env_variables
 
 
 StateChangeObserver = typing.Callable[['ModelInventory', SimulationId, Model, ProgressState],

--- a/simulation_orchestrator/simulation_logic/simulation_executor.py
+++ b/simulation_orchestrator/simulation_logic/simulation_executor.py
@@ -55,9 +55,9 @@ class SimulationExecutor:
         h.helicsFederateDestroy(message_federate)
 
     def _init_simulation(self, simulation : Simulation):
-        amount_of_helics_federates_esdl_message = sum([calculation_service.nr_of_models for calculation_service in simulation.calculation_services]) + 1 # SO is also a federate that is part of the esdl federation
-        amount_of_helics_federates = sum([calculation_service.nr_of_models * calculation_service.amount_of_calculations for calculation_service in simulation.calculation_services]) # SO is also a federate that is part of the federation
         models = simulation.model_inventory.get_models()
+        amount_of_helics_federates_esdl_message = len(models) + 1 # SO is also a federate that is part of the esdl federation
+        amount_of_helics_federates = sum([model.calc_service.amount_of_calculations for model in models])
         broker_ip = self.k8s_api.deploy_helics_broker(amount_of_helics_federates, amount_of_helics_federates_esdl_message, simulation.simulation_id, simulation.simulator_id)
         calculation_service_names = [calculation_service.esdl_type for calculation_service in simulation.calculation_services]
         for model in models:

--- a/test/TestActions.py
+++ b/test/TestActions.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from simulation_orchestrator import actions, parse_esdl
+from simulation_orchestrator.dataclasses.CalculationServiceInfo import CalculationServiceInfo
 from simulation_orchestrator.simulation_logic.model_inventory import Model
 from simulation_orchestrator.simulation_logic.simulation_executor import SimulationExecutor
 from simulation_orchestrator.simulation_logic.simulation_inventory import SimulationInventory
@@ -27,7 +28,7 @@ class TestActions(unittest.TestCase):
         self.parse_esdl_get_energy_system = parse_esdl.get_energy_system
         self.actions_simulation_executor = actions.simulation_executor.deploy_simulation
         actions.simulation_executor.deploy_simulation = MagicMock()
-        self.mock_model = Model('test-model-id', ['test-esdl-id'], 'service-name', 'service-url', 'PVInstallation', ProgressState.REGISTERED, [])
+        self.mock_model = Model("test", ["test"], CalculationServiceInfo("test", "test", 1, 1, "test", ["test"], []), ProgressState.DEPLOYED)
         parse_esdl.get_model_list = MagicMock(return_value=[self.mock_model])
         parse_esdl.get_energy_system = MagicMock(return_value=None)
 

--- a/test/TestParse.py
+++ b/test/TestParse.py
@@ -73,9 +73,9 @@ class TestParse(unittest.TestCase):
 
         # Assert
         self.assertEqual(sum([calculation_service_e_connection.nr_of_models, calculation_service_pv_installation.nr_of_models, calculation_service_energy_system.nr_of_models]), len(model_list))
-        energy_system_models = [model for model in model_list if model.calc_service_name == calculation_service_energy_system.calc_service_name]
-        pv_installation_models = [model for model in model_list if model.calc_service_name == calculation_service_pv_installation.calc_service_name]
-        e_connection_models = [model for model in model_list if model.calc_service_name == calculation_service_e_connection.calc_service_name]
+        energy_system_models = [model for model in model_list if model.calc_service.calc_service_name == calculation_service_energy_system.calc_service_name]
+        pv_installation_models = [model for model in model_list if model.calc_service.calc_service_name == calculation_service_pv_installation.calc_service_name]
+        e_connection_models = [model for model in model_list if model.calc_service.calc_service_name == calculation_service_e_connection.calc_service_name]
 
         first_pv_installation_model = pv_installation_models[0]
         second_pv_installation_model = pv_installation_models[1]


### PR DESCRIPTION
fix that amount of federates is being set based on the models that are deployed instead of the the calculation services that are supplied